### PR TITLE
Add level0 thumbnail to interstitial preview

### DIFF
--- a/src/components/Previews/Interstitial.tsx
+++ b/src/components/Previews/Interstitial.tsx
@@ -21,9 +21,7 @@ export const Interstitial: React.FC<InterstitialProps> = ({
   size,
   text,
 }) => {
-  const resource: string = getResourceURI(painting);
-  const img: string = `${resource}/full/${size},/0/default.jpg`;
-  const lqip: string = `${resource}/full/20,/0/default.jpg`;
+  const { img, lqip } = getResourceURI(painting, size);
 
   return (
     <InterstitialStyled css={{ height: size }}>
@@ -40,7 +38,9 @@ export const Interstitial: React.FC<InterstitialProps> = ({
         <div>
           <img src={img} style={{ width: size }} />
           {/* <a>Expand in Viewer</a> */}
-          <LQIP css={{ backgroundImage: `url(${lqip})` }} />
+          {lqip && (
+            <LQIP css={{ backgroundImage: `url(${lqip})` }} />
+          )}
         </div>
       </div>
     </InterstitialStyled>

--- a/src/dev.tsx
+++ b/src/dev.tsx
@@ -10,6 +10,9 @@ const App: React.FC = () => {
         <Yith.Manifest id="https://iiif.harvardartmuseums.org/manifests/object/299837" />
         <Yith.Manifest id="https://ub-iiif.vercel.app/api/manifest/marcus/ubb-bs-fol-00428" />
       </Yith>
+      <Yith type='presentation' preview='interstitial' text='Text'>
+        <Yith.Manifest id='https://ub-iiif.vercel.app/api/manifest/marcus/ubb-ms-0504' />
+      </Yith>
       <Yith type="projection">
         <Yith.Manifest id="https://iiif.harvardartmuseums.org/manifests/object/55652">
           <Yith.Canvas id="https://iiif.harvardartmuseums.org/manifests/object/55652/canvas/canvas-18724207" />


### PR DESCRIPTION
Hi, @mathewjordan!
I tried to install v1.0.29 yesterday and could not get it to work with my sad level0 images. Have tried to investigate and found that did not change the interstitial preview. So this PR is for that.

But when installing from NPM it does not work with my manifests, the old `getResourceURI` is still there. The previous PR was merged, but could those changes not have made it to NPM? Not been built before publishing?